### PR TITLE
add copyright and improving waitUtils

### DIFF
--- a/client/src/main/java/com/paypal/selion/platform/mobile/MobileObjectInstantiationException.java
+++ b/client/src/main/java/com/paypal/selion/platform/mobile/MobileObjectInstantiationException.java
@@ -1,3 +1,18 @@
+/*-------------------------------------------------------------------------------------------------------------------*\
+|  Copyright (C) 2016 PayPal                                                                                          |
+|                                                                                                                     |
+|  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
+|  with the License.                                                                                                  |
+|                                                                                                                     |
+|  You may obtain a copy of the License at                                                                            |
+|                                                                                                                     |
+|       http://www.apache.org/licenses/LICENSE-2.0                                                                    |
+|                                                                                                                     |
+|  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed   |
+|  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for  |
+|  the specific language governing permissions and limitations under the License.                                     |
+\*-------------------------------------------------------------------------------------------------------------------*/
+
 package com.paypal.selion.platform.mobile;
 
 public class MobileObjectInstantiationException extends RuntimeException {

--- a/client/src/main/java/com/paypal/selion/platform/utilities/WebDriverWaitUtils.java
+++ b/client/src/main/java/com/paypal/selion/platform/utilities/WebDriverWaitUtils.java
@@ -1,5 +1,5 @@
 /*-------------------------------------------------------------------------------------------------------------------*\
- |  Copyright (C) 2014-15 PayPal                                                                                       |
+|  Copyright (C) 2014-2016 PayPal                                                                                     |
 |                                                                                                                     |
 |  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
 |  with the License.                                                                                                  |
@@ -17,6 +17,7 @@ package com.paypal.selion.platform.utilities;
 
 import java.util.Arrays;
 
+import com.paypal.selion.platform.mobile.elements.MobileElement;
 import org.apache.commons.lang.StringUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
@@ -70,6 +71,16 @@ public final class WebDriverWaitUtils {
     /**
      * Waits until element is cickable.
      *
+     * @param element
+     *            element to be cickable
+     */
+    public static void waitUntilElementIsClickable(final MobileElement element) {
+        waitUntilElementIsClickable(element.getLocator());
+    }
+
+    /**
+     * Waits until element is cickable.
+     *
      * @param elementLocator
      *            identifier of element to be cickable
      */
@@ -79,6 +90,16 @@ public final class WebDriverWaitUtils {
         ExpectedCondition<WebElement> condition = ExpectedConditions.elementToBeClickable(by);
         waitForCondition(condition);
         logger.exiting();
+    }
+
+    /**
+     * Waits until element is either invisible or not present on the DOM.
+     *
+     * @param element
+     *            element to be found
+     */
+    public static void waitUntilElementIsInvisible(final MobileElement element) {
+        waitUntilElementIsInvisible(element.getLocator());
     }
 
     /**
@@ -99,6 +120,17 @@ public final class WebDriverWaitUtils {
      * Waits until element element is present on the DOM of a page. This does not necessarily mean that the element is
      * visible.
      * 
+     * @param element
+     *            element to be found
+     */
+    public static void waitUntilElementIsPresent(final MobileElement element) {
+        waitUntilElementIsPresent(element.getLocator());
+    }
+
+    /**
+     * Waits until element element is present on the DOM of a page. This does not necessarily mean that the element is
+     * visible.
+     *
      * @param elementLocator
      *            identifier of element to be found
      */
@@ -108,6 +140,17 @@ public final class WebDriverWaitUtils {
         ExpectedCondition<WebElement> condition = ExpectedConditions.presenceOfElementLocated(by);
         waitForCondition(condition);
         logger.exiting();
+    }
+
+    /**
+     * Waits until element is present on the DOM of a page and visible. Visibility means that the element is not only
+     * displayed but also has a height and width that is greater than 0.
+     *
+     * @param element
+     *            element to be visible
+     */
+    public static void waitUntilElementIsVisible(final MobileElement element) {
+        waitUntilElementIsVisible(element.getLocator());
     }
 
     /**
@@ -186,7 +229,7 @@ public final class WebDriverWaitUtils {
     public static void waitUntilPageIsValidated(WebPage pageObject) {
         logger.entering(pageObject);
         Preconditions.checkArgument(pageObject != null, "Please provide a valid instance of WebPage.");
-        final WebPage w = (WebPage) pageObject;
+        final WebPage w = pageObject;
         ExpectedCondition<Boolean> conditionToCheck = new ExpectedCondition<Boolean>() {
             @Override
             public Boolean apply(WebDriver webDriver) {

--- a/client/src/test/java/com/paypal/selion/mobile/sample/SampleMobilePage.java
+++ b/client/src/test/java/com/paypal/selion/mobile/sample/SampleMobilePage.java
@@ -1,3 +1,18 @@
+/*-------------------------------------------------------------------------------------------------------------------*\
+|  Copyright (C) 2016 PayPal                                                                                          |
+|                                                                                                                     |
+|  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
+|  with the License.                                                                                                  |
+|                                                                                                                     |
+|  You may obtain a copy of the License at                                                                            |
+|                                                                                                                     |
+|       http://www.apache.org/licenses/LICENSE-2.0                                                                    |
+|                                                                                                                     |
+|  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed   |
+|  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for  |
+|  the specific language governing permissions and limitations under the License.                                     |
+\*-------------------------------------------------------------------------------------------------------------------*/
+
 package com.paypal.selion.mobile.sample;
 
 import com.paypal.selion.internal.platform.grid.WebDriverPlatform;

--- a/client/src/test/java/com/paypal/selion/mobile/sample/mobile/SamplePage.java
+++ b/client/src/test/java/com/paypal/selion/mobile/sample/mobile/SamplePage.java
@@ -1,3 +1,18 @@
+/*-------------------------------------------------------------------------------------------------------------------*\
+|  Copyright (C) 2016 PayPal                                                                                          |
+|                                                                                                                     |
+|  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
+|  with the License.                                                                                                  |
+|                                                                                                                     |
+|  You may obtain a copy of the License at                                                                            |
+|                                                                                                                     |
+|       http://www.apache.org/licenses/LICENSE-2.0                                                                    |
+|                                                                                                                     |
+|  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed   |
+|  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for  |
+|  the specific language governing permissions and limitations under the License.                                     |
+\*-------------------------------------------------------------------------------------------------------------------*/
+
 package com.paypal.selion.mobile.sample.mobile;
 
 import com.paypal.selion.internal.platform.grid.WebDriverPlatform;

--- a/client/src/test/java/com/paypal/selion/mobile/sample/mobile/StatePage.java
+++ b/client/src/test/java/com/paypal/selion/mobile/sample/mobile/StatePage.java
@@ -1,3 +1,18 @@
+/*-------------------------------------------------------------------------------------------------------------------*\
+|  Copyright (C) 2016 PayPal                                                                                          |
+|                                                                                                                     |
+|  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
+|  with the License.                                                                                                  |
+|                                                                                                                     |
+|  You may obtain a copy of the License at                                                                            |
+|                                                                                                                     |
+|       http://www.apache.org/licenses/LICENSE-2.0                                                                    |
+|                                                                                                                     |
+|  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed   |
+|  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for  |
+|  the specific language governing permissions and limitations under the License.                                     |
+\*-------------------------------------------------------------------------------------------------------------------*/
+
 package com.paypal.selion.mobile.sample.mobile;
 
 import com.paypal.selion.internal.platform.grid.WebDriverPlatform;

--- a/client/src/test/java/com/paypal/selion/mobile/sample/mobile/TablePage.java
+++ b/client/src/test/java/com/paypal/selion/mobile/sample/mobile/TablePage.java
@@ -1,3 +1,18 @@
+/*-------------------------------------------------------------------------------------------------------------------*\
+|  Copyright (C) 2016 PayPal                                                                                          |
+|                                                                                                                     |
+|  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
+|  with the License.                                                                                                  |
+|                                                                                                                     |
+|  You may obtain a copy of the License at                                                                            |
+|                                                                                                                     |
+|       http://www.apache.org/licenses/LICENSE-2.0                                                                    |
+|                                                                                                                     |
+|  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed   |
+|  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for  |
+|  the specific language governing permissions and limitations under the License.                                     |
+\*-------------------------------------------------------------------------------------------------------------------*/
+
 package com.paypal.selion.mobile.sample.mobile;
 
 import com.paypal.selion.internal.platform.grid.WebDriverPlatform;

--- a/client/src/test/java/com/paypal/selion/mobile/sample/mobile/TapPage.java
+++ b/client/src/test/java/com/paypal/selion/mobile/sample/mobile/TapPage.java
@@ -1,3 +1,18 @@
+/*-------------------------------------------------------------------------------------------------------------------*\
+|  Copyright (C) 2016 PayPal                                                                                          |
+|                                                                                                                     |
+|  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
+|  with the License.                                                                                                  |
+|                                                                                                                     |
+|  You may obtain a copy of the License at                                                                            |
+|                                                                                                                     |
+|       http://www.apache.org/licenses/LICENSE-2.0                                                                    |
+|                                                                                                                     |
+|  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed   |
+|  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for  |
+|  the specific language governing permissions and limitations under the License.                                     |
+\*-------------------------------------------------------------------------------------------------------------------*/
+
 package com.paypal.selion.mobile.sample.mobile;
 
 import com.paypal.selion.internal.platform.grid.WebDriverPlatform;

--- a/client/src/test/java/com/paypal/selion/mobile/sample/mobile/TouchPage.java
+++ b/client/src/test/java/com/paypal/selion/mobile/sample/mobile/TouchPage.java
@@ -1,3 +1,18 @@
+/*-------------------------------------------------------------------------------------------------------------------*\
+|  Copyright (C) 2016 PayPal                                                                                          |
+|                                                                                                                     |
+|  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
+|  with the License.                                                                                                  |
+|                                                                                                                     |
+|  You may obtain a copy of the License at                                                                            |
+|                                                                                                                     |
+|       http://www.apache.org/licenses/LICENSE-2.0                                                                    |
+|                                                                                                                     |
+|  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed   |
+|  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for  |
+|  the specific language governing permissions and limitations under the License.                                     |
+\*-------------------------------------------------------------------------------------------------------------------*/
+
 package com.paypal.selion.mobile.sample.mobile;
 
 import com.paypal.selion.internal.platform.grid.WebDriverPlatform;


### PR DESCRIPTION
- add missing copyright to files.
- while working with framework, i found out must of the time you will be waiting for Element, and almost every use of waitUtils contains element.getLocator(), so i added some overload to wait elements in WaitUtils.
